### PR TITLE
Provided default implementations of AtomicAdd and AtomicCAS

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -4,6 +4,5 @@
 int main(int argc, char** argv)
 {
     jc_test_init(&argc, argv);
-    jc_test_run_all();
-    return 0;
+    return jc_test_run_all();
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -7,7 +7,7 @@
 
 TEST(Nadir, AtomicFilledIndexPool)
 {
-    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(15)), 15, nadir::AtomicAdd32, nadir::AtomicCAS32);
+    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(15)), 15);
 
     for(uint32_t i = 1; i <= 15; ++i)
     {
@@ -31,7 +31,7 @@ TEST(Nadir, AtomicFilledIndexPool)
 
 TEST(Nadir, AtomicEmptyIndexPool)
 {
-    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(16)), 0, nadir::AtomicAdd32, nadir::AtomicCAS32);
+    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(16)), 0);
 
     AtomicIndexPool_Push(pool, 1);
     ASSERT_EQ(1u, AtomicIndexPool_Pop(pool));
@@ -59,7 +59,7 @@ TEST(Nadir, TestAtomicFiloThreads)
 
 	for (uint32_t t = 0; t < 5; ++t)
 	{
-        HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(ENTRY_COUNT)), 0, nadir::AtomicAdd32, nadir::AtomicCAS32);
+        HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(ENTRY_COUNT)), 0);
 		struct Data
 		{
 			Data()

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,7 +5,7 @@
 
 #include "../third-party/jctest/src/jc_test.h"
 
-TEST(Nadir, AtomicFilledIndexPool)
+TEST(AtomicIndexPool, AtomicFilledIndexPool)
 {
     HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(15)), 15);
 
@@ -29,7 +29,7 @@ TEST(Nadir, AtomicFilledIndexPool)
     free(pool);
 }
 
-TEST(Nadir, AtomicEmptyIndexPool)
+TEST(AtomicIndexPool, AtomicEmptyIndexPool)
 {
     HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(16)), 0);
 
@@ -52,7 +52,7 @@ TEST(Nadir, AtomicEmptyIndexPool)
     free(pool);
 }
 
-TEST(Nadir, TestAtomicFiloThreads)
+TEST(AtomicIndexPool, TestAtomicFiloThreads)
 {
     #define ENTRY_BREAK_COUNT 311
     static const uint32_t ENTRY_COUNT = 391;

--- a/test/test_c99.c
+++ b/test/test_c99.c
@@ -2,25 +2,9 @@
 
 #include <stdlib.h>
 
-static long AtomicAdd32(long volatile* value, long amount)
-{
-    *value += amount;
-    return *value;
-}
-
-static long AtomicCAS32(long volatile* store, long compare, long value)
-{
-    long old_value = *store;
-    if (old_value == compare)
-    {
-        *store = value;
-    }
-    return old_value;
-}
-
 static void TestC99()
 {
-    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(15)), 15, AtomicAdd32, AtomicCAS32);
+    HAtomicIndexPool pool = AtomicIndexPool_Create(malloc(AtomicIndexPool_GetSize(15)), 15);
 
     uint32_t i = AtomicIndexPool_Pop(pool);
     AtomicIndexPool_Push(pool, i);


### PR DESCRIPTION
Works for GCC and clang. Works with MSVC when targeting Windows.